### PR TITLE
fix: Use correct parent-child endpoint for TicketNotes (fixes 404 error)

### DIFF
--- a/autotask_mcp.py
+++ b/autotask_mcp.py
@@ -7,7 +7,7 @@ company and contact management, time entries, ticket notes, and more.
 
 Key Features:
 - Ticket CRUD operations
-- TicketNotes creation (proper endpoint: /TicketNotes)
+- TicketNotes creation (proper endpoint: /Tickets/{id}/Notes)
 - TimeEntries creation (proper endpoint: /TimeEntries)
 - Company and Contact search
 - Resource lookup
@@ -411,7 +411,7 @@ async def autotask_create_ticket_note(params: CreateTicketNoteInput) -> str:
     """
     Create a note on a ticket in Autotask.
     
-    Uses the /TicketNotes endpoint (not /Tickets/{id}/Notes).
+    Uses the /Tickets/{id}/Notes endpoint (parent-child pattern).
     
     Required fields:
     - ticketId: The ticket to add the note to
@@ -433,7 +433,6 @@ async def autotask_create_ticket_note(params: CreateTicketNoteInput) -> str:
     Use autotask_get_picklist_values to get exact values for your instance.
     """
     note_data = {
-        "ticketID": params.ticket_id,
         "description": params.description,
         "noteType": params.note_type,
         "publish": params.publish,
@@ -442,7 +441,7 @@ async def autotask_create_ticket_note(params: CreateTicketNoteInput) -> str:
     if params.title:
         note_data["title"] = params.title
     
-    result = _make_request("POST", "TicketNotes", data=note_data)
+    result = _make_request("POST", f"Tickets/{params.ticket_id}/Notes", data=note_data)
     
     if "error" in result:
         return f"Error creating ticket note: {result['error']}\nDetails: {result.get('response_text', 'No details')}\n\nRequest data:\n{json.dumps(note_data, indent=2)}"
@@ -778,7 +777,7 @@ async def autotask_update_ticket_status_with_note(params: UpdateTicketStatusAndN
         "noteType": params.note_type,
         "publish": params.publish,
     }
-    note_result = _make_request("POST", "TicketNotes", data=note_data)
+    note_result = _make_request("POST", f"Tickets/{params.ticket_id}/Notes", data=note_data)
     
     if "error" in note_result:
         results.append(f"❌ Note creation failed: {note_result['error']}\nDetails: {note_result.get('response_text', 'No details')}")


### PR DESCRIPTION
## Summary

Fixes the `autotask_create_ticket_note` tool which was returning 404 errors when attempting to create ticket notes.

## Problem

The Autotask REST API requires TicketNotes to be created using a parent-child URL pattern (`/Tickets/{id}/Notes`), not a standalone endpoint (`/TicketNotes`). The current implementation was using the incorrect endpoint, causing all note creation attempts to fail with HTTP 404.

## Changes

- Changed endpoint from `POST /TicketNotes` to `POST /Tickets/{ticket_id}/Notes`
- Removed `ticketID` from request payload (now specified in URL path)
- Updated docstrings to reflect correct endpoint pattern
- Also fixed the same issue in `autotask_update_ticket_status_with_note` helper

## Testing

Tested against Autotask instance (ww14.autotask.net):
- ✅ Note creation now succeeds
- ✅ Notes appear correctly in Autotask UI

## Related

This fix aligns with Autotask REST API documentation on [child collection access URLs](https://ww14.autotask.net/help/DeveloperHelp/Content/APIs/REST/API_Calls/REST_Resource_Child_Access_URLs.htm).